### PR TITLE
Delete old (and one duplicate) codes: AI, AFI

### DIFF
--- a/packages/fhir.tx.support.r4/package/CodeSystem-iso3166.json
+++ b/packages/fhir.tx.support.r4/package/CodeSystem-iso3166.json
@@ -311,34 +311,6 @@
       ]
     },
     {
-      "code": "AI",
-      "display": "French Afars and Issas",
-      "definition": "French Afars and Issas",
-      "designation": [
-        {
-          "language": "fr",
-          "value": "Afars et Issas"
-        }
-      ]
-    },
-    {
-      "code": "AFI",
-      "display": "French Afars and Issas",
-      "definition": "French Afars and Issas",
-      "designation": [
-        {
-          "language": "fr",
-          "value": "Afars et Issas"
-        }
-      ],
-      "property": [
-        {
-          "code": "canonical",
-          "valueCode": "AI"
-        }
-      ]
-    },
-    {
       "code": "AL",
       "display": "Albania",
       "definition": "the Republic of Albania",


### PR DESCRIPTION
These code were retired to ISO 3166-3 in 1977