### PR TITLE
setup ig for maps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,10 @@ hs_err_pid*
 *.bak
 
 us.cdc.phinvads-source/
+
+interversion/r5/input-cache
+interversion/r5/output
+interversion/r5/temp
+interversion/r5/template
+interversion/r5/FHIR-xverr5.xml
+interversion/r5/txCache

--- a/interversion/r5/hl7.fhir.uv.xverr5.xml
+++ b/interversion/r5/hl7.fhir.uv.xverr5.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ImplementationGuide xmlns="http://hl7.org/fhir" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://hl7.org/fhir ../input-cache/schemas/R4/fhir-single.xsd">
+  <id value="hl7.fhir.uv.xverr5"/>
+  <url value="http://hl7.org/fhir"/>
+  <version value="3.0.0"/>
+  <name value="Xver R5"/>
+  <title value="Xver R5"/>
+  <status value="draft"/>
+  <experimental value="false"/>
+  <publisher value="HL7 International - FHIR Infrastructure Work Group"/>
+  <contact>
+    <telecom>
+      <system value="url"/>
+      <value value="http://hl7.org/Special/committees/fiwg"/>
+    </telecom>
+  </contact>
+  <description value="Interversion between R4, R4B and R5"/>
+  <jurisdiction>
+    <coding>
+      <system value="http://unstats.un.org/unsd/methods/m49/m49.htm"/>
+      <code value="001"/>
+    </coding>
+  </jurisdiction>
+  <packageId value="hl7.fhir.uv.xverr5"/>
+	<fhirVersion value="5.0.0-snapshot3" />
+  <dependsOn id="r4">
+    <uri value="http://hl7.org/fhir/4.0"/>
+    <packageId value="hl7.fhir.r4.core"/>
+    <version value="4.0.1"/>
+  </dependsOn>
+  <dependsOn id="r5">
+    <uri value="http://hl7.org/fhir/4.3"/>
+    <packageId value="hl7.fhir.r4b.core"/>
+    <version value="4.3.0"/>
+  </dependsOn>
+
+  <definition>
+      <!-- parameters -->
+    <parameter>
+      <code>
+        <code value="releaselabel"/>
+      </code>
+      <value value="DSTU 1"/>
+    </parameter>
+    <parameter>
+      <code>
+        <code value="path-resource"/>
+      </code>
+      <value value="r4-2-r5"/>
+    </parameter>
+    <parameter>
+      <code>
+        <code value="path-resource"/>
+      </code>
+      <value value="r4b-2-r5"/>
+    </parameter>
+    <parameter>
+      <code>
+        <code value="path-resource"/>
+      </code>
+      <value value="r5-2-r4"/>
+    </parameter>
+    <parameter>
+      <code>
+        <code value="path-resource"/>
+      </code>
+      <value value="r5-2-r4b"/>
+    </parameter>
+  </definition>
+
+</ImplementationGuide>

--- a/interversion/r5/ig.ini
+++ b/interversion/r5/ig.ini
@@ -1,0 +1,3 @@
+[IG]
+ig = hl7.fhir.uv.xverr5.xml
+template = hl7.fhir.template#current

--- a/interversion/r5/input/includes/menu.xml
+++ b/interversion/r5/input/includes/menu.xml
@@ -1,0 +1,5 @@
+<ul xmlns="http://www.w3.org/1999/xhtml" class="nav navbar-nav">
+  <!--<li><a href="toc.html">Table of Contents</a></li>-->
+  <li><a href="index.html">Home</a></li>
+  <li><a href="artifacts.html">Artifacts</a></li>
+</ul>


### PR DESCRIPTION
setup that the R4X <-> R5 maps are availabe within an ig hl7.fhir.uv.xverr5 in FHIR R5.

See https://github.com/HL7/fhir-ig-publisher/pull/626