### PR TITLE
Adding CAP eCP Codes

### DIFF
--- a/packages/fhir.tx.support.r4/package/CodeSystem-CAPeCP.json
+++ b/packages/fhir.tx.support.r4/package/CodeSystem-CAPeCP.json
@@ -11,8 +11,8 @@
       "value": "CAPeCP"
     }
   ],
-  "content": "example",
-  "version": "100004300",
+  "content": "fragment",
+  "version": "4.3.1.0",
   "name": "CAPeCPcodes",
   "title": "College of American Pathologists Electronic Cancer Protocol (eCP) Codes",
   "status": "active",

--- a/packages/fhir.tx.support.r4/package/CodeSystem-CAPeCP.json
+++ b/packages/fhir.tx.support.r4/package/CodeSystem-CAPeCP.json
@@ -1,7 +1,18 @@
 {
   "resourceType": "CodeSystem",
-  "content": "complete",
-  "version": "1.0",
+  "id": "CAPeCP",
+  "meta" : {
+    "lastUpdated" : "2023-12-06T10:50:13.533-5:00"
+  },
+  "url": "http://cap.org/eCP",
+  "identifier": [
+    {
+      "use": "official",
+      "value": "CAPeCP"
+    }
+  ],
+  "content": "example",
+  "version": "100004300",
   "name": "CAPeCPcodes",
   "title": "College of American Pathologists Electronic Cancer Protocol (eCP) Codes",
   "status": "active",

--- a/packages/fhir.tx.support.r4/package/CodeSystem-CAPeCP.json
+++ b/packages/fhir.tx.support.r4/package/CodeSystem-CAPeCP.json
@@ -12,7 +12,7 @@
     }
   ],
   "content": "fragment",
-  "version": "4.3.1.0",
+  "version": "4.000.001",
   "name": "CAPeCPcodes",
   "title": "College of American Pathologists Electronic Cancer Protocol (eCP) Codes",
   "status": "active",


### PR DESCRIPTION
Adding CAP eCP Codes in support of the IHE SDC/eCP on FHIR IG https://build.fhir.org/ig/HL7/ihe-sdc-ecc-on-fhir/

The codes are required to fix the terminology error on the QA page of that IG before it can be approved by TSC for STU1 publication 

CAP and HL7 have a licensing agreement in place for use of the eCPs in the IGs. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205319149011612