### PR TITLE
Fix table alignment for RTL languages

### DIFF
--- a/packages/hl7.fhir.pubpack/package/other/fhir.css
+++ b/packages/hl7.fhir.pubpack/package/other/fhir.css
@@ -212,7 +212,7 @@ table.codes td {
 table.grid{
 	margin-bottom: 10px;
         border: 1px black solid;
-        margin-right: auto;
+        margin-right: inherit;
 	
 }
 


### PR DESCRIPTION
This fixes table alignment to be on the right for RTL languages, while not affecting LTR languages. See https://github.com/HL7/fhir/pull/2943 for context.