### PR TITLE
Add codes used by PQCMC to NCIT fragment

### DIFF
--- a/packages/fhir.tx.support.r4/package/CodeSystem-nciThesaurus-fragment.json
+++ b/packages/fhir.tx.support.r4/package/CodeSystem-nciThesaurus-fragment.json
@@ -12072,6 +12072,10 @@
     {
       "code": "C54273",
       "display": "Picture"
+    },
+    {
+      "code": "C96971",
+      "display": "Nonproprietary Name"
     }
   ]
 }

--- a/packages/fhir.tx.support.r4/package/CodeSystem-nciThesaurus-fragment.json
+++ b/packages/fhir.tx.support.r4/package/CodeSystem-nciThesaurus-fragment.json
@@ -13,31 +13,31 @@
   "caseSensitive": true,
   "content": "fragment",
   "concept": [
-    { 
+    {
       "code": "C188404",
       "display": "Union for International Cancer Control Stage"
     },
-    { 
+    {
       "code": "C141206",
       "display": "Chronic Lymphocytic Leukemia- Modified Rai Staging System"
     },
-    { 
+    {
       "code": "C148012",
       "display": "Intergroup Rhabdomyosarcoma Group I"
     },
-    { 
+    {
       "code": "C148010",
       "display": "Intergroup Rhabdomyosarcoma Study Group Clinical Staging and Grouping System"
     },
-    { 
+    {
       "code": "C102402",
       "display": "Intermediate Risk"
     },
-    { 
+    {
       "code": "C7139",
       "display": "PRETEXT Stage 1 Hepatoblastoma"
     },
-    { 
+    {
       "code": "C198180",
       "display": "Stage 0 Childhood Retinoblastoma by Toronto Guidelines v2"
     },
@@ -594,8 +594,8 @@
       "display": "London Deauville Criteria Point Scale 5"
     },
     {
-      "code":"C49502",
-      "display":"Drug Withdrawn"
+      "code": "C49502",
+      "display": "Drug Withdrawn"
     },
     {
       "code": "C25716",
@@ -4211,7 +4211,16 @@
     },
     {
       "code": "C103201",
-      "display": "OPTICAL ACTIVITY"
+      "display": "OPTICAL ACTIVITY",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Optical Rotation"
+        }
+      ]
     },
     {
       "code": "C103202",
@@ -4399,7 +4408,16 @@
     },
     {
       "code": "C45305",
-      "display": "MIXTURE SUBSTANCE"
+      "display": "MIXTURE SUBSTANCE",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Mixture"
+        }
+      ]
     },
     {
       "code": "C45306",
@@ -4415,7 +4433,16 @@
     },
     {
       "code": "C48803",
-      "display": "POLYMER SUBSTANCE"
+      "display": "POLYMER SUBSTANCE",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Polymer"
+        }
+      ]
     },
     {
       "code": "C49160",
@@ -4423,7 +4450,16 @@
     },
     {
       "code": "C706",
-      "display": "NUCLEIC ACID SUBSTANCE"
+      "display": "NUCLEIC ACID SUBSTANCE",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Nucleic Acids"
+        }
+      ]
     },
     {
       "code": "C106325",
@@ -6415,7 +6451,16 @@
     },
     {
       "code": "C42938",
-      "display": "GRANULE"
+      "display": "GRANULE",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Granules"
+        }
+      ]
     },
     {
       "code": "C42939",
@@ -8007,7 +8052,16 @@
     },
     {
       "code": "C80440",
-      "display": "HUMANITARIAN DEVICE EXEMPTION"
+      "display": "HUMANITARIAN DEVICE EXEMPTION",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Humanitarian Device Exemption (HDE)"
+        }
+      ]
     },
     {
       "code": "C80441",
@@ -8015,7 +8069,16 @@
     },
     {
       "code": "C80442",
-      "display": "PREMARKET NOTIFICATION"
+      "display": "PREMARKET NOTIFICATION",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Premarket Notification 510(K)"
+        }
+      ]
     },
     {
       "code": "C80697",
@@ -8615,6 +8678,3400 @@
           "value": "Development"
         }
       ]
+    },
+    {
+      "code": "C133961",
+      "display": "Deliverable Volume/Fill Volume Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Deliverable Volume/Fill Volume"
+        }
+      ]
+    },
+    {
+      "code": "C133974",
+      "display": "Crystallinity Analysis",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Crystallinity"
+        }
+      ]
+    },
+    {
+      "code": "C133975",
+      "display": "Tablet Friability Determination",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Friability"
+        }
+      ]
+    },
+    {
+      "code": "C133979",
+      "display": "Viscosity/Rheological Property Analysis",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Viscosity/Rheological Properties"
+        }
+      ]
+    },
+    {
+      "code": "C133983",
+      "display": "Pyrogenicity/Endotoxin Assessment",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Pyrogenicity/Endotoxin"
+        }
+      ]
+    },
+    {
+      "code": "C133985",
+      "display": "Redispersibility Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Redispersibility"
+        }
+      ]
+    },
+    {
+      "code": "C134113",
+      "display": "Syringe Functionality Testing",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Syringe Functionality"
+        }
+      ]
+    },
+    {
+      "code": "C134114",
+      "display": "Total Organic Carbon Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Total Organic Carbon"
+        }
+      ]
+    },
+    {
+      "code": "C134249",
+      "display": "Container Closure Integrity Testing",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Container Closure Integrity"
+        }
+      ]
+    },
+    {
+      "code": "C134250",
+      "display": "Content Uniformity Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Uniformity"
+        }
+      ]
+    },
+    {
+      "code": "C134252",
+      "display": "Pharmaceutical Disintegration Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Disintegration"
+        }
+      ]
+    },
+    {
+      "code": "C134253",
+      "display": "Pharmaceutical Dissolution Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Dissolution"
+        }
+      ]
+    },
+    {
+      "code": "C134255",
+      "display": "Loss on Drying Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Loss on Drying"
+        }
+      ]
+    },
+    {
+      "code": "C134256",
+      "display": "Microbial Limit Determination",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Microbial Limits"
+        }
+      ]
+    },
+    {
+      "code": "C134257",
+      "display": "Particle Size Distribution Analysis",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Particle Size Distribution"
+        }
+      ]
+    },
+    {
+      "code": "C134260",
+      "display": "Powder Bulk Density Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Bulk Density"
+        }
+      ]
+    },
+    {
+      "code": "C134263",
+      "display": "Conductivity Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Conductivity"
+        }
+      ]
+    },
+    {
+      "code": "C134264",
+      "display": "Hardness Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Hardness"
+        }
+      ]
+    },
+    {
+      "code": "C134266",
+      "display": "Tap Density Determination",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Tap Density"
+        }
+      ]
+    },
+    {
+      "code": "C134267",
+      "display": "Plume Geometry Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Plume Geometry"
+        }
+      ]
+    },
+    {
+      "code": "C134269",
+      "display": "Polymorphic Form Determination",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Polymorphism"
+        }
+      ]
+    },
+    {
+      "code": "C134270",
+      "display": "Potency Assay",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Potency"
+        }
+      ]
+    },
+    {
+      "code": "C134272",
+      "display": "Reconstitution Time Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Reconstitution Time"
+        }
+      ]
+    },
+    {
+      "code": "C134276",
+      "display": "Residue on Ignition Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Residue on Ignition"
+        }
+      ]
+    },
+    {
+      "code": "C134277",
+      "display": "Spray Pattern Assessment",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Spray Pattern"
+        }
+      ]
+    },
+    {
+      "code": "C134278",
+      "display": "Sterility Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Sterility"
+        }
+      ]
+    },
+    {
+      "code": "C138993",
+      "display": "Material Identification Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Identification"
+        }
+      ]
+    },
+    {
+      "code": "C18951",
+      "display": "Post Translational Modification Analysis",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Post-translational Modifications"
+        }
+      ]
+    },
+    {
+      "code": "C193381",
+      "display": "Particulate Testing",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Foreign and Particulate Matter"
+        }
+      ]
+    },
+    {
+      "code": "C200004",
+      "display": "Cytotoxicity Assay",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Cytotoxicity"
+        }
+      ]
+    },
+    {
+      "code": "C204971",
+      "display": "Impurity Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Impurity"
+        }
+      ]
+    },
+    {
+      "code": "C205000",
+      "display": "Active Substance Functional Assay",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Functional Assays"
+        }
+      ]
+    },
+    {
+      "code": "C205012",
+      "display": "Droplet Size Test Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Droplet Size"
+        }
+      ]
+    },
+    {
+      "code": "C205013",
+      "display": "Elemental Analysis"
+    },
+    {
+      "code": "C205023",
+      "display": "Mechanical Integrity Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Mechanical Integrity"
+        }
+      ]
+    },
+    {
+      "code": "C205026",
+      "display": "Organoleptic Examination",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Organoleptic"
+        }
+      ]
+    },
+    {
+      "code": "C205027",
+      "display": "Osmolality/Osmolarity Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Osmolality/Osmolarity"
+        }
+      ]
+    },
+    {
+      "code": "C205029",
+      "display": "pH Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "pH"
+        }
+      ]
+    },
+    {
+      "code": "C205030",
+      "display": "Porosity Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Porosity"
+        }
+      ]
+    },
+    {
+      "code": "C205032",
+      "display": "Refractive Index Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Refractive Index"
+        }
+      ]
+    },
+    {
+      "code": "C205041",
+      "display": "Surface Area Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Surface Area"
+        }
+      ]
+    },
+    {
+      "code": "C205049",
+      "display": "Transdermal Device Property Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Transdermal Properties"
+        }
+      ]
+    },
+    {
+      "code": "C25483",
+      "display": "Dimension",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Material Properties/Measurements"
+        }
+      ]
+    },
+    {
+      "code": "C60819",
+      "display": "Assay"
+    },
+    {
+      "code": "C60821",
+      "display": "Solubility"
+    },
+    {
+      "code": "C63394",
+      "display": "Melting Point Determination",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Melting Point"
+        }
+      ]
+    },
+    {
+      "code": "C64832",
+      "display": "Specific Gravity"
+    },
+    {
+      "code": "C74723",
+      "display": "Turbidity Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Turbidity"
+        }
+      ]
+    },
+    {
+      "code": "C133992",
+      "display": "Clinical Batch",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Clinical"
+        }
+      ]
+    },
+    {
+      "code": "C133993",
+      "display": "Validation Batch",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Validation"
+        }
+      ]
+    },
+    {
+      "code": "C133994",
+      "display": "Bioequivalence Batch",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Bioequivalence"
+        }
+      ]
+    },
+    {
+      "code": "C133910",
+      "display": "MDL Molfile Format",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "MOLFILE"
+        }
+      ]
+    },
+    {
+      "code": "C133996",
+      "display": "MDL Structure-data File Format",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "SDF"
+        }
+      ]
+    },
+    {
+      "code": "C133997",
+      "display": "Macromolecular CIF",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "mmCIF (large molecules)"
+        }
+      ]
+    },
+    {
+      "code": "C49039",
+      "display": "Protein Data Bank",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "PDB"
+        }
+      ]
+    },
+    {
+      "code": "C54683",
+      "display": "International Chemical Identifier",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "InChI File (small molecule)"
+        }
+      ]
+    },
+    {
+      "code": "C54684",
+      "display": "Simplified Molecular Input Line Entry Specification",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "SMILES"
+        }
+      ]
+    },
+    {
+      "code": "C85435",
+      "display": "Scalable Vector Graphics",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "SVG"
+        }
+      ]
+    },
+    {
+      "code": "C133998",
+      "display": "Does Not Conform"
+    },
+    {
+      "code": "C80262",
+      "display": "Conformance",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Conforms"
+        }
+      ]
+    },
+    {
+      "code": "C133914",
+      "display": "Valve-up"
+    },
+    {
+      "code": "C133915",
+      "display": "Valve-down"
+    },
+    {
+      "code": "C133999",
+      "display": "Inverted"
+    },
+    {
+      "code": "C25241",
+      "display": "Horizontal"
+    },
+    {
+      "code": "C86043",
+      "display": "Upright"
+    },
+    {
+      "code": "C96141",
+      "display": "Petri Dish",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Dish, Petri"
+        }
+      ]
+    },
+    {
+      "code": "C96142",
+      "display": "Microwell Plate",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Plate, Microwell"
+        }
+      ]
+    },
+    {
+      "code": "C96143",
+      "display": "Lined Canister",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Canisters, lined"
+        }
+      ]
+    },
+    {
+      "code": "C96144",
+      "display": "Flask"
+    },
+    {
+      "code": "C134001",
+      "display": "Inorganic Impurity",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Inorganic"
+        }
+      ]
+    },
+    {
+      "code": "C176812",
+      "display": "Process Related Impurity",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Process Related/Process"
+        }
+      ]
+    },
+    {
+      "code": "C176813",
+      "display": "Product Related Impurity",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Product Related"
+        }
+      ]
+    },
+    {
+      "code": "C176815",
+      "display": "Residual Solvent"
+    },
+    {
+      "code": "C176816",
+      "display": "Degradant",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Degradation Product"
+        }
+      ]
+    },
+    {
+      "code": "C185190",
+      "display": "Elemental Impurity",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Elemental Impurities"
+        }
+      ]
+    },
+    {
+      "code": "C185192",
+      "display": "Leachable Material",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Leachables"
+        }
+      ]
+    },
+    {
+      "code": "C92081",
+      "display": "Microbial Contamination",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Microbiological"
+        }
+      ]
+    },
+    {
+      "code": "C48793",
+      "display": "Equivalent",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "EQ"
+        }
+      ]
+    },
+    {
+      "code": "C134006",
+      "display": "United States Pharmacopeia-National Formulary",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "USP-NF"
+        }
+      ]
+    },
+    {
+      "code": "C134007",
+      "display": "European Pharmacopeia",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "EP"
+        }
+      ]
+    },
+    {
+      "code": "C134008",
+      "display": "Japanese Pharmacopeia",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "JP"
+        }
+      ]
+    },
+    {
+      "code": "C134009",
+      "display": "Company Standard"
+    },
+    {
+      "code": "C176793",
+      "display": "British Pharmacopeia",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "BP"
+        }
+      ]
+    },
+    {
+      "code": "C14182",
+      "display": "Animal"
+    },
+    {
+      "code": "C14225",
+      "display": "Human"
+    },
+    {
+      "code": "C14227",
+      "display": "Insect"
+    },
+    {
+      "code": "C14258",
+      "display": "Plant"
+    },
+    {
+      "code": "C14329",
+      "display": "Microorganism",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Microbial"
+        }
+      ]
+    },
+    {
+      "code": "C18634",
+      "display": "Animal Sources",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Animal-derived indirectly"
+        }
+      ]
+    },
+    {
+      "code": "C48807",
+      "display": "Chemical"
+    },
+    {
+      "code": "C134010",
+      "display": "Tentative Approval",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Tentatively Approved"
+        }
+      ]
+    },
+    {
+      "code": "C134011",
+      "display": "Not Approved"
+    },
+    {
+      "code": "C134012",
+      "display": "Reported in a CBE or AR"
+    },
+    {
+      "code": "C25425",
+      "display": "Approval",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Approved"
+        }
+      ]
+    },
+    {
+      "code": "C48660",
+      "display": "Not Applicable"
+    },
+    {
+      "code": "C133931",
+      "display": "Raw Materials/Excipients/Intermediates/Reagents Specification",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Raw Materials/Excipients/Intermediates/Reagents"
+        }
+      ]
+    },
+    {
+      "code": "C134021",
+      "display": "Drug Product Specification",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Drug Product"
+        }
+      ]
+    },
+    {
+      "code": "C134022",
+      "display": "Drug Substance Specification",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Drug Substance"
+        }
+      ]
+    },
+    {
+      "code": "C96148",
+      "display": "Proprietary Storage Condition",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Proprietary"
+        }
+      ]
+    },
+    {
+      "code": "C134026",
+      "display": "Standard Environmental Condition",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Standard"
+        }
+      ]
+    },
+    {
+      "code": "C134027",
+      "display": "Cycled-Simple Environmental Condition",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Cycled-Simple"
+        }
+      ]
+    },
+    {
+      "code": "C134028",
+      "display": "Complex Environmental Condition",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Complex"
+        }
+      ]
+    },
+    {
+      "code": "C96087",
+      "display": "Photostability Drug Study",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Photostability"
+        }
+      ]
+    },
+    {
+      "code": "C96102",
+      "display": "Compendial Method",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Compendial"
+        }
+      ]
+    },
+    {
+      "code": "C96103",
+      "display": "Proprietary Method",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Proprietary"
+        }
+      ]
+    },
+    {
+      "code": "C96164",
+      "display": "Code of Federal Regulations Method",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "CFR"
+        }
+      ]
+    },
+    {
+      "code": "C134029",
+      "display": "Release Determination",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Release"
+        }
+      ]
+    },
+    {
+      "code": "C134030",
+      "display": "Stability Determination",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Stability"
+        }
+      ]
+    },
+    {
+      "code": "C61583",
+      "display": "Greater Than or Equal To",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "NLT (not less than)"
+        }
+      ]
+    },
+    {
+      "code": "C61584",
+      "display": "Greater Than",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "MT (more than)"
+        }
+      ]
+    },
+    {
+      "code": "C61585",
+      "display": "Less Than",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "LT (less than)"
+        }
+      ]
+    },
+    {
+      "code": "C61586",
+      "display": "Less Than or Equal To",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "NMT (not more than)"
+        }
+      ]
+    },
+    {
+      "code": "C134003",
+      "display": "Data Universal Numbering System",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "DUNS"
+        }
+      ]
+    },
+    {
+      "code": "C134004",
+      "display": "Facility FDA Establishment Identifier",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "FEI"
+        }
+      ]
+    },
+    {
+      "code": "C134005",
+      "display": "Central File Number",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "CFN"
+        }
+      ]
+    },
+    {
+      "code": "C17998",
+      "display": "Unknown"
+    },
+    {
+      "code": "C168628",
+      "display": "Drug Component Mass",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Mass"
+        }
+      ]
+    },
+    {
+      "code": "C45420",
+      "display": "Biochemical Activity",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Activity"
+        }
+      ]
+    },
+    {
+      "code": "C2140",
+      "display": "Adjuvant"
+    },
+    {
+      "code": "C42637",
+      "display": "Pharmaceutical Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Inactive Ingredient"
+        }
+      ]
+    },
+    {
+      "code": "C82533",
+      "display": "Active Ingredient"
+    },
+    {
+      "code": "C176632",
+      "display": "Emollient Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Emollient"
+        }
+      ]
+    },
+    {
+      "code": "C176633",
+      "display": "Emulsion Stabilizing Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Emulsion stabilizing agent"
+        }
+      ]
+    },
+    {
+      "code": "C176634",
+      "display": "Foam Stabilizing Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Foam stabilizing agent"
+        }
+      ]
+    },
+    {
+      "code": "C176635",
+      "display": "Organoleptic Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Organoleptic agent"
+        }
+      ]
+    },
+    {
+      "code": "C176636",
+      "display": "Stabilizing Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Stabilizer"
+        }
+      ]
+    },
+    {
+      "code": "C176637",
+      "display": "Absorption Modifying Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Absorption modifier"
+        }
+      ]
+    },
+    {
+      "code": "C176638",
+      "display": "Effervescent Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Effervescent agent"
+        }
+      ]
+    },
+    {
+      "code": "C176639",
+      "display": "Reducing Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Reducing agent"
+        }
+      ]
+    },
+    {
+      "code": "C176640",
+      "display": "Solubilizing Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Solubilizing agent"
+        }
+      ]
+    },
+    {
+      "code": "C176641",
+      "display": "Tonicity Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Tonicity agent"
+        }
+      ]
+    },
+    {
+      "code": "C176642",
+      "display": "Adsorbent"
+    },
+    {
+      "code": "C176643",
+      "display": "Air Displacement Agent",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Air displacement"
+        }
+      ]
+    },
+    {
+      "code": "C176644",
+      "display": "Bulking Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Bulking agent"
+        }
+      ]
+    },
+    {
+      "code": "C176645",
+      "display": "Carrier Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Carrier"
+        }
+      ]
+    },
+    {
+      "code": "C176646",
+      "display": "Complexing Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Complexing agent"
+        }
+      ]
+    },
+    {
+      "code": "C176647",
+      "display": "Denaturant"
+    },
+    {
+      "code": "C176648",
+      "display": "Film Coating Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Film coating agent"
+        }
+      ]
+    },
+    {
+      "code": "C176649",
+      "display": "Free Radical Scavenging Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Free radical scavenger"
+        }
+      ]
+    },
+    {
+      "code": "C176650",
+      "display": "Gelling Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Gelling agent"
+        }
+      ]
+    },
+    {
+      "code": "C176651",
+      "display": "Humectant Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Humectant"
+        }
+      ]
+    },
+    {
+      "code": "C176652",
+      "display": "Lyophilization Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Lyophilization aid"
+        }
+      ]
+    },
+    {
+      "code": "C176653",
+      "display": "Matrix Forming Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Matrix-forming agent"
+        }
+      ]
+    },
+    {
+      "code": "C176654",
+      "display": "Microencapsulating Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Microencapsulating agent"
+        }
+      ]
+    },
+    {
+      "code": "C176655",
+      "display": "Ointment Base"
+    },
+    {
+      "code": "C176656",
+      "display": "Opacifying Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Opacifier"
+        }
+      ]
+    },
+    {
+      "code": "C176657",
+      "display": "Osmotic Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Osmotic agent"
+        }
+      ]
+    },
+    {
+      "code": "C176658",
+      "display": "pH Modifying Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "pH modifier"
+        }
+      ]
+    },
+    {
+      "code": "C176659",
+      "display": "Polishing Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Polishing agent"
+        }
+      ]
+    },
+    {
+      "code": "C176660",
+      "display": "Ophthalmic Polymer",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Polymers for ophthalmic use"
+        }
+      ]
+    },
+    {
+      "code": "C176661",
+      "display": "Propellant"
+    },
+    {
+      "code": "C176662",
+      "display": "Release Modifying Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Release modifying agent"
+        }
+      ]
+    },
+    {
+      "code": "C176663",
+      "display": "Suppository Base"
+    },
+    {
+      "code": "C176664",
+      "display": "Transdermal Delivery Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Transdermal delivery component"
+        }
+      ]
+    },
+    {
+      "code": "C176665",
+      "display": "Transfer Ligand Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Transfer ligand"
+        }
+      ]
+    },
+    {
+      "code": "C176666",
+      "display": "Viscosity Modifying Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Viscosity modifier"
+        }
+      ]
+    },
+    {
+      "code": "C176667",
+      "display": "Water Repelling Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Water-repelling agent"
+        }
+      ]
+    },
+    {
+      "code": "C176668",
+      "display": "Wetting Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Wetting agent"
+        }
+      ]
+    },
+    {
+      "code": "C275",
+      "display": "Antioxidant"
+    },
+    {
+      "code": "C360",
+      "display": "Chelating Agent"
+    },
+    {
+      "code": "C42647",
+      "display": "Binder Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Binder"
+        }
+      ]
+    },
+    {
+      "code": "C42648",
+      "display": "Disintegrant Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Disintegrant"
+        }
+      ]
+    },
+    {
+      "code": "C42650",
+      "display": "Filler Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Filler"
+        }
+      ]
+    },
+    {
+      "code": "C42653",
+      "display": "Lubricant Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Lubricant"
+        }
+      ]
+    },
+    {
+      "code": "C42654",
+      "display": "Glidant Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Anticaking agent"
+        }
+      ]
+    },
+    {
+      "code": "C42656",
+      "display": "Color Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Coloring agent"
+        }
+      ]
+    },
+    {
+      "code": "C42657",
+      "display": "Printing Ink Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Ink"
+        }
+      ]
+    },
+    {
+      "code": "C42659",
+      "display": "Preservative Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Preservative"
+        }
+      ]
+    },
+    {
+      "code": "C42660",
+      "display": "Suspending Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Suspending agent"
+        }
+      ]
+    },
+    {
+      "code": "C42662",
+      "display": "Dispersing Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Dispersing agent"
+        }
+      ]
+    },
+    {
+      "code": "C42739",
+      "display": "Surfactant Excipient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Surfactant"
+        }
+      ]
+    },
+    {
+      "code": "C45790",
+      "display": "Solvent"
+    },
+    {
+      "code": "C53306",
+      "display": "Cryoprotective Agent",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Cryoprotectant"
+        }
+      ]
+    },
+    {
+      "code": "C55826",
+      "display": "Plasticizer"
+    },
+    {
+      "code": "C70815",
+      "display": "Buffer",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Buffering agent"
+        }
+      ]
+    },
+    {
+      "code": "C73477",
+      "display": "Emulsifying Excipient"
+    },
+    {
+      "code": "C89528",
+      "display": "Adhesive Device",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Adhesive"
+        }
+      ]
+    },
+    {
+      "code": "C927",
+      "display": "Drug Vehicle",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Vehicle"
+        }
+      ]
+    },
+    {
+      "code": "C185182",
+      "display": "Master File or Application Approved Indicator",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Approved"
+        }
+      ]
+    },
+    {
+      "code": "C185186",
+      "display": "Adequate Substance Process Understanding",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Adequate"
+        }
+      ]
+    },
+    {
+      "code": "C185188",
+      "display": "Proposed Substance Date Change",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Proposed"
+        }
+      ]
+    },
+    {
+      "code": "C96150",
+      "display": "Immediate Testing"
+    },
+    {
+      "code": "C96151",
+      "display": "Delayed Testing"
+    },
+    {
+      "code": "C96153",
+      "display": "Frozen Delayed Testing"
+    },
+    {
+      "code": "C96154",
+      "display": "Ambient Delayed Testing"
+    },
+    {
+      "code": "C96155",
+      "display": "Refrigerated Delayed Testing"
+    },
+    {
+      "code": "C203348",
+      "display": "Hard Gelatin Capsule Shell"
+    },
+    {
+      "code": "C203349",
+      "display": "Hard HPMC Capsule Shell"
+    },
+    {
+      "code": "C203350",
+      "display": "Hard Pullulan Capsule Shell"
+    },
+    {
+      "code": "C203351",
+      "display": "Hard PVA Capsule Shell"
+    },
+    {
+      "code": "C203352",
+      "display": "Hard Starch Capsule Shell"
+    },
+    {
+      "code": "C203353",
+      "display": "Soft Gelatin Capsule Shell"
+    },
+    {
+      "code": "C203359",
+      "display": "Matrix Drug Release",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Matrix"
+        }
+      ]
+    },
+    {
+      "code": "C203360",
+      "display": "Osmotic Pump Drug Release",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Osmotic Pump"
+        }
+      ]
+    },
+    {
+      "code": "C203361",
+      "display": "Reservoir Drug Release",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Reservoir"
+        }
+      ]
+    },
+    {
+      "code": "C142585",
+      "display": "International Nonproprietary Name",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "INN"
+        }
+      ]
+    },
+    {
+      "code": "C203354",
+      "display": "Company Identifier",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Company ID/Code"
+        }
+      ]
+    },
+    {
+      "code": "C203355",
+      "display": "GSRS Preferred Term"
+    },
+    {
+      "code": "C203356",
+      "display": "IUPAC Name"
+    },
+    {
+      "code": "C203357",
+      "display": "Chemical Systematic Name",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Systematic Name"
+        }
+      ]
+    },
+    {
+      "code": "C203358",
+      "display": "USP-NF Established Name"
+    },
+    {
+      "code": "C54682",
+      "display": "CAS Number"
+    },
+    {
+      "code": "C71898",
+      "display": "Proprietary Name",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Brand"
+        }
+      ]
+    },
+    {
+      "code": "C95517",
+      "display": "ISBT-128 Donation Identification Number",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "ISBT-128 DIN"
+        }
+      ]
+    },
+    {
+      "code": "C96973",
+      "display": "United States Adopted Name",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "USAN"
+        }
+      ]
+    },
+    {
+      "code": "C97054",
+      "display": "Generic Name"
+    },
+    {
+      "code": "C203881",
+      "display": "Active Core Granule",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Active core/granulate"
+        }
+      ]
+    },
+    {
+      "code": "C203882",
+      "display": "Extragranular Ingredient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Extragranular"
+        }
+      ]
+    },
+    {
+      "code": "C203883",
+      "display": "Intragranular Ingredient",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Intragranular"
+        }
+      ]
+    },
+    {
+      "code": "C42669",
+      "display": "Immediate Release Dosage Form",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Immediate Release Profile"
+        }
+      ]
+    },
+    {
+      "code": "C42713",
+      "display": "Extended Release Dosage Form",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Extended-Release Profile"
+        }
+      ]
+    },
+    {
+      "code": "C42730",
+      "display": "Delayed Release Dosage Form",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Delayed-Release Profile"
+        }
+      ]
+    },
+    {
+      "code": "C203884",
+      "display": "Appearance Promoting Coating",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Appearance/Identification"
+        }
+      ]
+    },
+    {
+      "code": "C203885",
+      "display": "Consumption Promoting Coating",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Consumption Enhancement"
+        }
+      ]
+    },
+    {
+      "code": "C203886",
+      "display": "Isolate Promoting Coating",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Content Isolation"
+        }
+      ]
+    },
+    {
+      "code": "C203887",
+      "display": "Delayed Release Coating",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Delayed Release"
+        }
+      ]
+    },
+    {
+      "code": "C203888",
+      "display": "Drug Layering Coating",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Drug Layering"
+        }
+      ]
+    },
+    {
+      "code": "C203889",
+      "display": "Extended Release Coating",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Extended Release"
+        }
+      ]
+    },
+    {
+      "code": "C203890",
+      "display": "Irritant Suppression Coating",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Irritant Suppression"
+        }
+      ]
+    },
+    {
+      "code": "C203891",
+      "display": "Odor Masking Coating",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Odor Masking"
+        }
+      ]
+    },
+    {
+      "code": "C203892",
+      "display": "Protective Coating",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Protective"
+        }
+      ]
+    },
+    {
+      "code": "C203893",
+      "display": "Seal Coating",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Seal"
+        }
+      ]
+    },
+    {
+      "code": "C203894",
+      "display": "Site Delivery Coating",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Site of Action"
+        }
+      ]
+    },
+    {
+      "code": "C203895",
+      "display": "Taste Masking Coating",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Taste Masking"
+        }
+      ]
+    },
+    {
+      "code": "C202489",
+      "display": "Dispersion Dosage Form",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Dispersion"
+        }
+      ]
+    },
+    {
+      "code": "C203896",
+      "display": "Blended Dry Mixture",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Blend"
+        }
+      ]
+    },
+    {
+      "code": "C203897",
+      "display": "Capsule Shell"
+    },
+    {
+      "code": "C203898",
+      "display": "Minitablet Dosage Form",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Minitablets"
+        }
+      ]
+    },
+    {
+      "code": "C25450",
+      "display": "Coat",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Coating"
+        }
+      ]
+    },
+    {
+      "code": "C66831",
+      "display": "Layer"
+    },
+    {
+      "code": "C134002",
+      "display": "Residual Solvent Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Residual Solvent"
+        }
+      ]
+    },
+    {
+      "code": "C134115",
+      "display": "Uniformity of Dosage Units Analysis",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Uniformity of Dosage Unit"
+        }
+      ]
+    },
+    {
+      "code": "C134254",
+      "display": "Impurities/Degradation Products/Related Substances Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Impurities/Degradation Products/Related Substances"
+        }
+      ]
+    },
+    {
+      "code": "C134261",
+      "display": "Clarity of Solution Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Clarity of Solution"
+        }
+      ]
+    },
+    {
+      "code": "C134262",
+      "display": "Color of Solution Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Color of Solution"
+        }
+      ]
+    },
+    {
+      "code": "C138990",
+      "display": "Product Description/Appearance Assessment",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Description/Appearance"
+        }
+      ]
+    },
+    {
+      "code": "C139027",
+      "display": "Odor Detection",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Odor"
+        }
+      ]
+    },
+    {
+      "code": "C16643",
+      "display": "Protein Glycosylation",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Glycosylation"
+        }
+      ]
+    },
+    {
+      "code": "C171277",
+      "display": "Nucleic Acid Concentration Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Nucleic Acid Content"
+        }
+      ]
+    },
+    {
+      "code": "C204845",
+      "display": "Active Ingredient Assay",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Active Ingredient Content"
+        }
+      ]
+    },
+    {
+      "code": "C204890",
+      "display": "Chemical Impurity Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Impurity Chemical"
+        }
+      ]
+    },
+    {
+      "code": "C205001",
+      "display": "Adventitious Agent Assay",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Adventitious Agents (Safety)"
+        }
+      ]
+    },
+    {
+      "code": "C205002",
+      "display": "Amidation Assay",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Amidation"
+        }
+      ]
+    },
+    {
+      "code": "C205003",
+      "display": "Bioburden Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Bioburden"
+        }
+      ]
+    },
+    {
+      "code": "C205004",
+      "display": "Blend Uniformity Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Blend Uniformity"
+        }
+      ]
+    },
+    {
+      "code": "C205005",
+      "display": "Capsule Lock Length Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Lock Length"
+        }
+      ]
+    },
+    {
+      "code": "C205006",
+      "display": "Cell and Gene Therapy Product Characterization Assay"
+    },
+    {
+      "code": "C205007",
+      "display": "Counterion Content Assessment",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Counterion Content"
+        }
+      ]
+    },
+    {
+      "code": "C205008",
+      "display": "Deamidation Assessment",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Deamidation"
+        }
+      ]
+    },
+    {
+      "code": "C205009",
+      "display": "Dose Orifice Depth Drilled Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Orifice Depth"
+        }
+      ]
+    },
+    {
+      "code": "C205010",
+      "display": "Dose Orifice Diameter Drilled Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Orifice Diameter"
+        }
+      ]
+    },
+    {
+      "code": "C205011",
+      "display": "Dose Orifice Location Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Orifice Location"
+        }
+      ]
+    },
+    {
+      "code": "C205014",
+      "display": "Elemental Impurity Analysis",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Elemental Impurity"
+        }
+      ]
+    },
+    {
+      "code": "C205015",
+      "display": "Excipient Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Excipient"
+        }
+      ]
+    },
+    {
+      "code": "C205016",
+      "display": "Group Fill Substance Weight Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Group Fill Weight"
+        }
+      ]
+    },
+    {
+      "code": "C205017",
+      "display": "Group Substance Weight Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Group Weight"
+        }
+      ]
+    },
+    {
+      "code": "C205018",
+      "display": "Host Cell DNA Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Host Cell DNA"
+        }
+      ]
+    },
+    {
+      "code": "C205019",
+      "display": "In Process Control Content Uniformity Tests",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "IPC Content Uniformity"
+        }
+      ]
+    },
+    {
+      "code": "C205020",
+      "display": "In Vitro or In Vivo Test for Viral Contaminants"
+    },
+    {
+      "code": "C205021",
+      "display": "Individual Substance Fill Weight Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Individual Fill Weight"
+        }
+      ]
+    },
+    {
+      "code": "C205022",
+      "display": "Individual Substance Weight Measurement ",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Individual Weight"
+        }
+      ]
+    },
+    {
+      "code": "C205024",
+      "display": "Metal Level Detection Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Metal Detection"
+        }
+      ]
+    },
+    {
+      "code": "C205025",
+      "display": "Number of Dose Orifices Drilled Count",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Number of Orifices"
+        }
+      ]
+    },
+    {
+      "code": "C205028",
+      "display": "Percent Conjugated Protein Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Percent Conjugate"
+        }
+      ]
+    },
+    {
+      "code": "C205031",
+      "display": "Protein Sialylation",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Sialylation"
+        }
+      ]
+    },
+    {
+      "code": "C205033",
+      "display": "Ribbon Density"
+    },
+    {
+      "code": "C205034",
+      "display": "Ribbon Thickness"
+    },
+    {
+      "code": "C205035",
+      "display": "Seam Thickness Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Seam Thickness"
+        }
+      ]
+    },
+    {
+      "code": "C205036",
+      "display": "Shell Weight Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Shell Weight"
+        }
+      ]
+    },
+    {
+      "code": "C205037",
+      "display": "Single or Double Drilled Side Assessment",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Drilled Side (Single or Double)"
+        }
+      ]
+    },
+    {
+      "code": "C205038",
+      "display": "Solvate Content Identification",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Solvate Content"
+        }
+      ]
+    },
+    {
+      "code": "C205039",
+      "display": "Specified Identified Impurity Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Specified Identified Impurity"
+        }
+      ]
+    },
+    {
+      "code": "C205040",
+      "display": "Specified Unidentified Impurity Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Specified Unidentified Impurity"
+        }
+      ]
+    },
+    {
+      "code": "C205042",
+      "display": "Tablet Thickness Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Tablet Thickness"
+        }
+      ]
+    },
+    {
+      "code": "C205043",
+      "display": "Tablet/Capsule Diameter Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Tablet/Capsule Diameter"
+        }
+      ]
+    },
+    {
+      "code": "C205044",
+      "display": "Tablet/Capsule Length Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Tablet/Capsule Length"
+        }
+      ]
+    },
+    {
+      "code": "C205045",
+      "display": "Target Group Product Weight Gain Percentage",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Target Group Weight Gain %"
+        }
+      ]
+    },
+    {
+      "code": "C205047",
+      "display": "Total Product Impurity above Threshold Assay",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Total Impurities"
+        }
+      ]
+    },
+    {
+      "code": "C205048",
+      "display": "Total Product Unknown Impurity Assay",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Total Unknown Impurities"
+        }
+      ]
+    },
+    {
+      "code": "C205050",
+      "display": "Content Uniformity in Container",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Uniformity in Containers"
+        }
+      ]
+    },
+    {
+      "code": "C205051",
+      "display": "Unspecified Product Impurity below ICH Identification Threshold",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Identified Impurity under IT, Monitored as Unspecified"
+        }
+      ]
+    },
+    {
+      "code": "C205052",
+      "display": "Unspecified Product Impurity Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Unspecified Impurity"
+        }
+      ]
+    },
+    {
+      "code": "C205053",
+      "display": "Weight/Concentration Variation Test",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Weight Variation"
+        }
+      ]
+    },
+    {
+      "code": "C205054",
+      "display": "Thrombin Peptide Map"
+    },
+    {
+      "code": "C205206",
+      "display": "Average Fill Substance Weight Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Average Fill Weight"
+        }
+      ]
+    },
+    {
+      "code": "C205209",
+      "display": "Average Substance Weight Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Average Weight"
+        }
+      ]
+    },
+    {
+      "code": "C62352",
+      "display": "Purity Assessment",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Purity"
+        }
+      ]
+    },
+    {
+      "code": "C64858",
+      "display": "Total Protein Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Total Protein"
+        }
+      ]
+    },
+    {
+      "code": "C81183",
+      "display": "Amino Acid Measurement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Amino Acid Content"
+        }
+      ]
+    },
+    {
+      "code": "C17021",
+      "display": "Protein"
+    },
+    {
+      "code": "C149895",
+      "display": "Semi-solid"
+    },
+    {
+      "code": "C45298",
+      "display": "Liquid"
+    },
+    {
+      "code": "C45299",
+      "display": "Gas"
+    },
+    {
+      "code": "C45300",
+      "display": "Solid"
+    },
+    {
+      "code": "C154433",
+      "display": "Capsule Dose Form Category",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Capsule"
+        }
+      ]
+    },
+    {
+      "code": "C154605",
+      "display": "Tablet Dosage Form Category",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Tablet"
+        }
+      ]
+    },
+    {
+      "code": "C154598",
+      "display": "Solution Dosage Form Category",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Solution"
+        }
+      ]
+    },
+    {
+      "code": "C115122",
+      "display": "Generic Investigational New Animal Drug File"
+    },
+    {
+      "code": "C115123",
+      "display": "Abbreviated New Animal Drug Application"
+    },
+    {
+      "code": "C70877",
+      "display": "Drug Master File",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Master File"
+        }
+      ]
+    },
+    {
+      "code": "C70880",
+      "display": "Pre-market Approval Application",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Premarket Approval"
+        }
+      ]
+    },
+    {
+      "code": "C71778",
+      "display": "Biologics License Application"
+    },
+    {
+      "code": "C72899",
+      "display": "New Drug Application"
+    },
+    {
+      "code": "C72901",
+      "display": "New Animal Drug Application"
+    },
+    {
+      "code": "C73113",
+      "display": "Abbreviated New Drug Application"
+    },
+    {
+      "code": "C82667",
+      "display": "Investigational Device Exemption"
+    },
+    {
+      "code": "C96089",
+      "display": "Annual Report"
+    },
+    {
+      "code": "C96090",
+      "display": "Investigational New Drug Application"
+    },
+    {
+      "code": "C96091",
+      "display": "Investigational New Animal Drug File"
+    },
+    {
+      "code": "C96092",
+      "display": "New Active Ingredient"
+    },
+    {
+      "code": "C96094",
+      "display": "Approved Application Supplement",
+      "designation": [
+        {
+          "use": {
+            "system": "http://snomed.info/sct",
+            "code": "900000000000013009"
+          },
+          "value": "Supplement to an Approved Application"
+        }
+      ]
+    },
+    {
+      "code": "C45253",
+      "display": "String"
+    },
+    {
+      "code": "C54273",
+      "display": "Picture"
     }
   ]
 }

--- a/packages/fhir.tx.support.r4/package/CodeSystem-nciThesaurus-fragment.json
+++ b/packages/fhir.tx.support.r4/package/CodeSystem-nciThesaurus-fragment.json
@@ -18,22 +18,6 @@
       "display": "Union for International Cancer Control Stage"
     },
     {
-      "code": "C141206",
-      "display": "Chronic Lymphocytic Leukemia- Modified Rai Staging System"
-    },
-    {
-      "code": "C148012",
-      "display": "Intergroup Rhabdomyosarcoma Group I"
-    },
-    {
-      "code": "C148010",
-      "display": "Intergroup Rhabdomyosarcoma Study Group Clinical Staging and Grouping System"
-    },
-    {
-      "code": "C102402",
-      "display": "Intermediate Risk"
-    },
-    {
       "code": "C7139",
       "display": "PRETEXT Stage 1 Hepatoblastoma"
     },
@@ -592,10 +576,6 @@
     {
       "code": "C99750",
       "display": "London Deauville Criteria Point Scale 5"
-    },
-    {
-      "code": "C49502",
-      "display": "Drug Withdrawn"
     },
     {
       "code": "C25716",
@@ -11575,7 +11555,7 @@
     },
     {
       "code": "C205022",
-      "display": "Individual Substance Weight Measurement ",
+      "display": "Individual Substance Weight Measurement",
       "designation": [
         {
           "use": {


### PR DESCRIPTION
Adds the codes used by [PQCMC-FDA](https://github.com/HL7/FHIR-us-pq-cmc-fda) to the NCIT fragment in fhir.tx.support.r4.
All codes are in the latest version of [NCI thesaurus](https://evs.nci.nih.gov/ftp1/NCI_Thesaurus/). The display for every concept is the NCIt preferred term, and if the PQCMC preferred term differs, it is added as a synonym designation (all the PQCMC preferred terms are already synonyms in NCIt).
Tested with a terminology endpoint on a local copy of the [Pascal FHIR Server](https://github.com/HealthIntersections/fhirserver) and it worked fine.