### PR TITLE
add ICH Context of Use codes

### DIFF
--- a/packages/fhir.tx.support.r4/package/CodeSystem-ICH-context-of-use.json
+++ b/packages/fhir.tx.support.r4/package/CodeSystem-ICH-context-of-use.json
@@ -1,0 +1,589 @@
+{
+  "id": "v4-ICHContextOfUse",
+  "resourceType": "CodeSystem",
+  "url": "http://terminology.hl7.org/CodeSystem/ICHContextOfUse",
+  "name": "ICHContextOfUse",
+  "title": "ICH Context of Use",
+  "status": "active",
+  "experimental": false,
+  "date": "2025-05-22",
+  "publisher": "International Council for Harmonisation of Technical Requirements for Pharmaceuticals for Human Use (ICH)",
+  "description": "Codes are found within the vocabulary package at the link above which is available from this page: [https://ich.org/page/ich-electronic-common-technical-document-ectd-v40](https://ich.org/page/ich-electronic-common-technical-document-ectd-v40). Specifically, the codes are in the “ICH Context of Use” tab of the \"ICH M8 OID Listing_eCTDv4_v5.xlsx\" workbook. The codes are part of the ICH implementation of HL7 V3 Standard: Regulated Studies; Regulated Product Submissions (RPS), Release 2 Normative (described here: [https://www.hl7.org/implement/standards/product_brief.cfm?product_id=38](https://www.hl7.org/implement/standards/product_brief.cfm?product_id=38))\r\n\r\nWhen using this uri in FHIR, the version identifier is mandatory and the code system uri cannot be used without it.\r\n\r\nThis system uses an integer based versioning system in conjunction with an OID update. For example, if the version of the system is v5, the OID is 2.16.840.1.113883.3.989.2.2.1.1.5. This system has an OID stem of 2.16.840.1.113883.3.989.2.2.1.1.",
+  "copyright": "\"The information, material and photographic content provided on this website are protected by copyright and may, with the exception of the ICH logo, be used, reproduced, incorporated into other works, adapted, modified, translated or distributed under a public license provided that ICH's copyright in the information and material is acknowledged at all times. In case of any adaption, modification or translation of the information, material or photographic content, reasonable steps must be taken to clearly label, demarcate or otherwise identify that changes were made to or based on the original information or material. Any impression that the adaption, modification or translation of the original information or material is endorsed or sponsored by the ICH must be avoided.\"\r\n\r\nFor more information, see [https://ich.org/page/legal-mentions](https://ich.org/page/legal-mentions)",
+  "caseSensitive": true,
+  "content": "fragment",
+  "concept": [
+    {
+      "code": "ich_3.2.p.4.5",
+      "display": "m3.2.p.4.5 excipients of human or animal origin"
+    },
+    {
+      "code": "ich_3.2.s",
+      "display": "m3.2.s drug substance"
+    },
+    {
+      "code": "ich_3.2.p.3.2",
+      "display": "m3.2.p.3.2 batch formula"
+    },
+    {
+      "code": "ich_2.7.5",
+      "display": "m2.7.5 literature references"
+    },
+    {
+      "code": "ich_3.2.p.2",
+      "display": "m3.2.p.2 pharmaceutical development"
+    },
+    {
+      "code": "ich_4.2.3.4.1",
+      "display": "m4.2.3.4.1 long-term studies"
+    },
+    {
+      "code": "ich_3.2.p.4.3",
+      "display": "m3.2.p.4.3 validation of analytical procedures"
+    },
+    {
+      "code": "ich_2.4",
+      "display": "m2.4 nonclinical overview"
+    },
+    {
+      "code": "ich_3.2.a.2",
+      "display": "m3.2.a.2 adventitious agents safety evaluation"
+    },
+    {
+      "code": "ich_3.2.p.8.2",
+      "display": "m3.2.p.8.2 post-approval stability protocol and stability commitment"
+    },
+    {
+      "code": "ich_3.2.s.2.4",
+      "display": "m3.2.s.2.4 controls of critical steps and intermediates"
+    },
+    {
+      "code": "ich_2.6.7",
+      "display": "m2.6.7 toxicology tabulated summary"
+    },
+    {
+      "code": "ich_3.2.p.2.1",
+      "display": "m3.2.p.2.1 components of the drug product"
+    },
+    {
+      "code": "ich_4.2.1.1",
+      "display": "m4.2.1 1 primary pharmacodynamics"
+    },
+    {
+      "code": "ich_2.3.p",
+      "display": "m2.3.p drug product"
+    },
+    {
+      "code": "ich_3.2.s.2.3",
+      "display": "m3.2.s.2.3 control of materials"
+    },
+    {
+      "code": "ich_2.3.a.2",
+      "display": "m2.3.a.2 adventitious agents safety evaluation"
+    },
+    {
+      "code": "ich_4.2.2.4",
+      "display": "m4.2.2.4 metabolism"
+    },
+    {
+      "code": "ich_4.2.2.7",
+      "display": "m4.2.2.7 other pharmacokinetic studies"
+    },
+    {
+      "code": "ich_5.3.2.3",
+      "display": "m5.3.2.3 reports of studies using other human biomaterials"
+    },
+    {
+      "code": "ich_4.2.3.7.3",
+      "display": "m4.2.3.7.3 mechanistic studies"
+    },
+    {
+      "code": "ich_5.3.3.4",
+      "display": "m5.3.3.4 extrinsic factor pk study reports"
+    },
+    {
+      "code": "ich_3.2.s.1",
+      "display": "m3.2.s.1 general information"
+    },
+    {
+      "code": "ich_5.3.5.3",
+      "display": "m5.3.5.3 reports of analyses of data from more than one study"
+    },
+    {
+      "code": "ich_2.6.5",
+      "display": "m2.6.5 pharmacokinetics tabulated summary"
+    },
+    {
+      "code": "ich_4.3",
+      "display": "m4.3 literature references"
+    },
+    {
+      "code": "ich_4.2.1.2",
+      "display": "m4.2.1 2 secondary pharmacodynamics"
+    },
+    {
+      "code": "ich_3.2.a.1",
+      "display": "m3.2.a.1 facilities and equipment"
+    },
+    {
+      "code": "ich_3.2.p.4",
+      "display": "m3.2.p.4 control of excipients"
+    },
+    {
+      "code": "ich_4.2.2.2",
+      "display": "m4.2.2 2 absorption"
+    },
+    {
+      "code": "ich_3.2.a",
+      "display": "m3.2.a appendices"
+    },
+    {
+      "code": "ich_3.2.p.4.1",
+      "display": "m3.2.p.4.1 specifications"
+    },
+    {
+      "code": "ich_2.6.3",
+      "display": "m2.6.3 pharmacology tabulated summary"
+    },
+    {
+      "code": "ich_3.2.p.2.5",
+      "display": "m3.2.p.2.5 microbiological attributes"
+    },
+    {
+      "code": "ich_2.7.4",
+      "display": "m2.7.4 summary of clinical safety"
+    },
+    {
+      "code": "ich_5.3.6",
+      "display": "m5.3.6 reports of postmarketing experience"
+    },
+    {
+      "code": "ich_3.2.p.2.4",
+      "display": "m3.2.p.2.4 container closure system"
+    },
+    {
+      "code": "ich_2.6.1",
+      "display": "m2.6.1 introduction"
+    },
+    {
+      "code": "Ich_2",
+      "display": "m2 common technical document summaries"
+    },
+    {
+      "code": "ich_4.2.3.1",
+      "display": "m4.2.3.1 single-dose toxicity"
+    },
+    {
+      "code": "ich_3.2.s.7.1",
+      "display": "m3.2.s.7.1 stability summary and conclusions"
+    },
+    {
+      "code": "ich_4.2.1.4",
+      "display": "m4.2.1 4 pharmacodynamic drug interactions"
+    },
+    {
+      "code": "ich_4.2.3.7.6",
+      "display": "m4.2.3.7.6 impurities"
+    },
+    {
+      "code": "ich_3.2.s.2.6",
+      "display": "m3.2.s.2.6 manufacturing process development"
+    },
+    {
+      "code": "ich_4.2.3.5.2",
+      "display": "m4.2.3.5.2 embryofetal development"
+    },
+    {
+      "code": "ich_3.2.p.2.6",
+      "display": "m3.2.p.2.6 compatibility"
+    },
+    {
+      "code": "ich_3.2.p.8.3",
+      "display": "m3.2.p.8.3 stability data"
+    },
+    {
+      "code": "ich_5.3.1.4",
+      "display": "m5.3.1 4 reports of bioanalytical and analytical methods for human studies"
+    },
+    {
+      "code": "ich_3.2.p.2.3",
+      "display": "m3.2.p.2.3 manufacturing process development"
+    },
+    {
+      "code": "ich_3.2.p.3.5",
+      "display": "m3.2.p.3.5 process validation and/or  evaluation"
+    },
+    {
+      "code": "ich_5.3.3.3",
+      "display": "m5.3.3 3 intrinsic factor pk study reports"
+    },
+    {
+      "code": "ich_5.3.5.2",
+      "display": "m5.3.5.2 study reports of uncontrolled clinical studies"
+    },
+    {
+      "code": "ich_5.3.4.1",
+      "display": "m5.3.4.1 healthy subject pd and pk/pd study reports"
+    },
+    {
+      "code": "ich_4.2.2.5",
+      "display": "m4.2.2.5 excretion"
+    },
+    {
+      "code": "ich_3.2.p.5.2",
+      "display": "m3.2.p.5.2 analytical procedures"
+    },
+    {
+      "code": "ich_3.2.s.2.5",
+      "display": "m3.2.s.2.5 process validation and/or  evaluation"
+    },
+    {
+      "code": "ich_5.3.2.1",
+      "display": "m5.3.2.1 plasma protein binding study reports"
+    },
+    {
+      "code": "ich_2.3.r",
+      "display": "m2.3.r regional information"
+    },
+    {
+      "code": "ich_3.2.s.3.2",
+      "display": "m3.2.s.3.2 impurities"
+    },
+    {
+      "code": "ich_4.2.3.3.2",
+      "display": "m4.2.3.3.2 in vivo"
+    },
+    {
+      "code": "ich_2.3.i",
+      "display": "m2.3 introduction"
+    },
+    {
+      "code": "ich_3.2.s.2.2",
+      "display": "m3.2.s.2.2 description of manufacturing process and process controls"
+    },
+    {
+      "code": "ich_3.2.s.2.1",
+      "display": "m3.2.s.2.1 manufacturer(s)"
+    },
+    {
+      "code": "ich_3.2.p.5.4",
+      "display": "m3.2.p.5.4 batch analyses"
+    },
+    {
+      "code": "ich_3.2.p.3.1",
+      "display": "m3.2.p.3.1 manufacturer(s)"
+    },
+    {
+      "code": "ich_2.5",
+      "display": "m2.5 clinical overview"
+    },
+    {
+      "code": "ich_3.2.s.3",
+      "display": "m3.2.s.3 characterisation"
+    },
+    {
+      "code": "ich_3.2.s.5",
+      "display": "m3.2.s.5 reference standards or materials"
+    },
+    {
+      "code": "ich_2.6.2",
+      "display": "m2.6.2 pharmacology written summary"
+    },
+    {
+      "code": "ich_3.2.s.4.2",
+      "display": "m3.2.s.4.2 analytical procedures"
+    },
+    {
+      "code": "ich_3.2.s.3.1",
+      "display": "m3.2.s.3.1 elucidation of structure and other characteristics"
+    },
+    {
+      "code": "ich_3.2.s.4.5",
+      "display": "m3.2.s.4.5 justification of specification"
+    },
+    {
+      "code": "ich_5.3.2.2",
+      "display": "m5.3.2.2 reports of hepatic metabolism and drug interaction studies"
+    },
+    {
+      "code": "ich_4.2.2.6",
+      "display": "m4.2.2.6 pharmacokinetic drug interactions"
+    },
+    {
+      "code": "ich_3.2.p.5.5",
+      "display": "m3.2.p.5.5 characterisation of impurities"
+    },
+    {
+      "code": "ich_3.2.s.4.4",
+      "display": "m3.2.s.4.4 batch analyses"
+    },
+    {
+      "code": "ich_4.2.3.6",
+      "display": "m4.2.3.6 local tolerance"
+    },
+    {
+      "code": "ich_3.2.s.2",
+      "display": "m3.2.s.2 manufacture"
+    },
+    {
+      "code": "ich_3.2.p.4.2",
+      "display": "m3.2.p.4.2 analytical procedures"
+    },
+    {
+      "code": "ich_4.2.3.7.7",
+      "display": "m4.2.3.7.7 other"
+    },
+    {
+      "code": "ich_5.3.1.1",
+      "display": "m5.3.1 1 bioavailability study reports"
+    },
+    {
+      "code": "ich_5.3.1.2",
+      "display": "m5.3.1 2 comparative ba and bioequivalence study reports"
+    },
+    {
+      "code": "ich_2.3.s",
+      "display": "m2.3.s drug substance"
+    },
+    {
+      "code": "ich_4.2.3.7.5",
+      "display": "m4.2.3.7.5 metabolites"
+    },
+    {
+      "code": "ich_3.2.s.4.1",
+      "display": "m3.2.s.4.1 specification"
+    },
+    {
+      "code": "ich_3.2.p.2.2",
+      "display": "m3.2.p.2.2 drug product"
+    },
+    {
+      "code": "ich_3.2.p.4.6",
+      "display": "m3.2.p.4.6 novel excipients"
+    },
+    {
+      "code": "ich_5.3.5.1",
+      "display": "m5.3.5.1 study reports of controlled clinical studies pertinent to the claimed indication"
+    },
+    {
+      "code": "ich_3.2.s.7.3",
+      "display": "m3.2.s.7.3 stability data"
+    },
+    {
+      "code": "ich_3.2.p.5.3",
+      "display": "m3.2.p.5.3 validation of analytical procedures"
+    },
+    {
+      "code": "ich_5.2",
+      "display": "m5.2 tabular listing of all clinical studies"
+    },
+    {
+      "code": "ich_2.7.1",
+      "display": "m2.7.1 summary of biopharmaceutic studies and associated analytical methods"
+    },
+    {
+      "code": "ich_4.2.3.3.1",
+      "display": "m4.2.3.3.1 in vitro"
+    },
+    {
+      "code": "ich_3.2.p.3",
+      "display": "m3.2.p.3 manufacture"
+    },
+    {
+      "code": "ich_2.3.a.1",
+      "display": "m2.3.a.1 facilities and equipment"
+    },
+    {
+      "code": "ich_4.2.2.3",
+      "display": "m4.2.2.3 distribution"
+    },
+    {
+      "code": "ich_4.2.3.2",
+      "display": "m4.2.3.2 repeat-dose toxicity"
+    },
+    {
+      "code": "ich_2.6.4",
+      "display": "m2.6.4 pharmacokinetics written summary"
+    },
+    {
+      "code": "ich_4.2.3.4.2",
+      "display": "m4.2.3.4.2 short or medium-term studies"
+    },
+    {
+      "code": "ich_4.2.3.5.1",
+      "display": "m4.2.3.5.1 fertility and early embryonic development"
+    },
+    {
+      "code": "ich_3.2.p.1",
+      "display": "m3.2.p.1 description and composition of the drug product"
+    },
+    {
+      "code": "ich_4.2.3.5.4",
+      "display": "m4.2.3.5.4 studies in which the offspring juvenile animals are dosed and/or further evaluated"
+    },
+    {
+      "code": "ich_5.4",
+      "display": "m5.4 literature references"
+    },
+    {
+      "code": "ich_3.3",
+      "display": "m3.3 literature references"
+    },
+    {
+      "code": "ich_5.3.3.5",
+      "display": "m5.3.3.5 population pk study reports"
+    },
+    {
+      "code": "ich_3.2.p.3.3",
+      "display": "m3.2.p.3.3 description of manufacturing process and process controls"
+    },
+    {
+      "code": "ich_5.3.4.2",
+      "display": "m5.3.4.2 patient pd and pk/pd study reports"
+    },
+    {
+      "code": "ich_2.7.2",
+      "display": "m2.7.2 summary of clinical pharmacology studies"
+    },
+    {
+      "code": "ich_2.3",
+      "display": "m2.3 quality overall summary"
+    },
+    {
+      "code": "ich_3.2.p.7",
+      "display": "m3.2.p.7 container closure system"
+    },
+    {
+      "code": "ich_3.2.p",
+      "display": "m3.2.p drug product"
+    },
+    {
+      "code": "ich_3.2.p.6",
+      "display": "m3.2.p.6 reference standards or materials"
+    },
+    {
+      "code": "ich_2.3.a.3",
+      "display": "m2.3.a.3 excipients"
+    },
+    {
+      "code": "ich_3.2.s.4",
+      "display": "m3.2.s.4 control of drug substance"
+    },
+    {
+      "code": "ich_3.2.p.3.4",
+      "display": "m3.2.p.3.4 controls of critical steps and intermediates"
+    },
+    {
+      "code": "ich_5.3.1.3",
+      "display": "m5.3.1 3 in vitro  in vivo correlation study reports"
+    },
+    {
+      "code": "ich_4.2.3.5.3",
+      "display": "m4.2.3.5.3 prenatal and postnatal development, including maternal function"
+    },
+    {
+      "code": "ich_5.3.7",
+      "display": "m5.3.7 case report forms and individual patient listings"
+    },
+    {
+      "code": "ich_3.2.a.3",
+      "display": "m3.2.a.3 excipients"
+    },
+    {
+      "code": "ich_5.3.3.2",
+      "display": "m5.3.3.2 patient pk and initial tolerability study reports"
+    },
+    {
+      "code": "ich_3.2.p.8",
+      "display": "m3.2.p.8 stability"
+    },
+    {
+      "code": "ich_2.6.6",
+      "display": "m2.6.6 toxicology written summary"
+    },
+    {
+      "code": "ich_3.2.s.4.3",
+      "display": "m3.2.s.4.3 validation of analytical procedures"
+    },
+    {
+      "code": "ich_4.2.2.1",
+      "display": "m4.2.2.1 analytical methods and validation reports"
+    },
+    {
+      "code": "ich_4.2.3.7.2",
+      "display": "m4.2.3.7.2 immunotoxicity"
+    },
+    {
+      "code": "ich_5.3.3.1",
+      "display": "m5.3.3.1 healthy subject pk and initial tolerability study reports"
+    },
+    {
+      "code": "ich_5.3.5.4",
+      "display": "m5.3.5.4 other study reports"
+    },
+    {
+      "code": "ich_3.2.s.7.2",
+      "display": "m3.2.s.7.2 post-approval stability protocol and stability commitment"
+    },
+    {
+      "code": "ich_2.7.6",
+      "display": "m2.7.6 synopses of individual studies"
+    },
+    {
+      "code": "ich_4.2.3.7.1",
+      "display": "m4.2.3.7.1 antigenicity"
+    },
+    {
+      "code": "ich_2.2",
+      "display": "m2.2 introduction"
+    },
+    {
+      "code": "ich_3.2.p.5.6",
+      "display": "m3.2.p.5.6 justification of specifications"
+    },
+    {
+      "code": "ich_3.2.p.8.1",
+      "display": "m3.2.p.8.1 stability summary and conclusion"
+    },
+    {
+      "code": "ich_3.2.r",
+      "display": "m3.2 r regional information"
+    },
+    {
+      "code": "ich_4.2.3.4.3",
+      "display": "m4.2.3.4.3 other studies"
+    },
+    {
+      "code": "ich_3.2.p.5",
+      "display": "m3.2.p.5 control of drug product"
+    },
+    {
+      "code": "ich_2.7.3",
+      "display": "m2.7.3 summary of clinical efficacy"
+    },
+    {
+      "code": "ich_4.2.1.3",
+      "display": "m4.2.1 3 safety pharmacology"
+    },
+    {
+      "code": "ich_3.2.p.4.4",
+      "display": "m3.2.p.4.4 justification of specifications"
+    },
+    {
+      "code": "ich_4.2.3.7.4",
+      "display": "m4.2.3.7.4 dependence"
+    },
+    {
+      "code": "ich_3.2.s.7",
+      "display": "m3.2.s.7 stability"
+    },
+    {
+      "code": "ich_3.2.p.5.1",
+      "display": "m3.2.p.5.1 specification(s)"
+    },
+    {
+      "code": "ich_3.2.s.6",
+      "display": "m3.2.s.6 container closure system"
+    }
+  ]
+}


### PR DESCRIPTION
See [the end of this zulip thread](https://chat.fhir.org/#narrow/channel/194616-terminology-.2F-utg/topic/HL7.20Terminology.20.28THO.29.20v6.2E3.2E0.20Release.20Announcement/with/519431535). Adds ICH's Context of Use codes found in the [.zip](https://admin.ich.org/sites/default/files/inline-files/eCTD_v4.0_Controlled_Vocabulary_Package_v1.0.2_0.zip) mentioned in the description of the [CodeSystem in the terminology package](https://terminology.hl7.org/6.3.0/CodeSystem-ICHContextOfUse.html).

Boilerplate is lifted from the [CodeSystem in the terminology package](https://terminology.hl7.org/6.3.0/CodeSystem-ICHContextOfUse.html).

Ran through the validator fine, only gave a warning for not having descriptions (which the original spreadsheet doesn't have).
Tested on a local terminology server, the publisher was able to find and use the codes for validation with no problems.