### PR TITLE
Add missing ISO 3166 user-assigned codes to R3 and R4

### DIFF
--- a/packages/fhir.tx.support.r3/package/CodeSystem-iso3166.json
+++ b/packages/fhir.tx.support.r3/package/CodeSystem-iso3166.json
@@ -23,7 +23,7 @@
   "copyright" : "Copyright ISO. See https://www.iso.org/obp/ui/#search/code/",
   "caseSensitive" : true,
   "content" : "complete",
-  "count" : 868,
+  "count" : 896,
   "property" : [
     {
       "code" : "canonical",
@@ -14987,6 +14987,174 @@
           "valueCode" : "ZW"
         }
       ]
+    },
+    {
+      "code" : "AA",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QM",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QN",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QO",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QP",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QQ",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QR",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QS",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QT",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QU",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QV",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QW",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QX",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QY",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QZ",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XA",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XB",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XC",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XD",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XE",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XF",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XG",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XH",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XI",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XJ",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XK",
+      "display" : "Kosovo"
+    },
+    {
+      "code" : "XL",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XM",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XN",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XO",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XP",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XQ",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XR",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XS",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XT",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XU",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XV",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XW",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XX",
+      "display" : "Unknown"
+    },
+    {
+      "code" : "XY",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XZ",
+      "display" : "International Waters"
+    },
+    {
+      "code" : "ZZ",
+      "display" : "Unknown or Invalid Territory"
     }
   ]
 }

--- a/packages/fhir.tx.support.r4/package/CodeSystem-iso3166.json
+++ b/packages/fhir.tx.support.r4/package/CodeSystem-iso3166.json
@@ -18,12 +18,14 @@
   "compositional" : false,
   "versionNeeded" : false,
   "content" : "complete",
-  "count" : 747,
+  "count" : 789,
   "filter" : [
     {
       "code" : "code",
       "description" : "Filter by the code",
-      "operator" : ["regex"],
+      "operator" : [
+        "regex"
+      ],
       "value" : "concept.code"
     }
   ],
@@ -7504,6 +7506,174 @@
           "valueString" : "Vierges britanniques (les Îles)"
         }
       ]
+    },
+    {
+      "code" : "AA",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QM",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QN",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QO",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QP",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QQ",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QR",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QS",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QT",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QU",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QV",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QW",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QX",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QY",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "QZ",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XA",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XB",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XC",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XD",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XE",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XF",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XG",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XH",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XI",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XJ",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XK",
+      "display" : "Kosovo"
+    },
+    {
+      "code" : "XL",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XM",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XN",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XO",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XP",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XQ",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XR",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XS",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XT",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XU",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XV",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XW",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XX",
+      "display" : "Unknown"
+    },
+    {
+      "code" : "XY",
+      "display" : "User-assigned"
+    },
+    {
+      "code" : "XZ",
+      "display" : "International Waters"
+    },
+    {
+      "code" : "ZZ",
+      "display" : "Unknown or Invalid Territory"
     }
   ]
 }


### PR DESCRIPTION
ISO 3166-1 reserves codes AA, QM-QZ, XA-XZ, and ZZ for user assignment. These are present in the tx.fhir.org 2018 version but missing from the R4 (20210120) and R3 (57) versions.